### PR TITLE
Update theme switcher to show current selected theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ const availableThemes: string[] = [
 
 - After following the above steps, your new theme should appear in the dropdown menu and be selectable.
 
+> Notice that theme names with more than 15 characters will be truncated when shown inside the themes dropdown menu
+
 ## 📌 Get Ready to Sextar!
 
 Stay tuned for more updates and fun features! Until then... is it time to "sextar"? 🤔

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,11 @@ import esLintConfigPrettier from 'eslint-config-prettier/flat'
 export default tseslint.config(
   { ignores: ['dist'] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended, esLintConfigPrettier],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended,
+      esLintConfigPrettier,
+    ],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,11 +8,12 @@ import ThemeSelect from './components/ThemeSelect.tsx'
 
 function App() {
   const [response, setResponse] = useState('Pensando...')
-  const [theme, setTheme] = useState('')
+  const [theme, setTheme] = useState(
+    localStorage.getItem('theme') ? localStorage.getItem('theme') : null,
+  )
 
   function handleThemeChange(theme: string) {
-    if (theme != '' && theme != 'system') localStorage.setItem('theme', theme)
-    if (theme === 'system') localStorage.removeItem('theme')
+    if (theme != '') localStorage.setItem('theme', theme)
     setTheme(theme)
   }
 
@@ -24,7 +25,7 @@ function App() {
     document.documentElement.className = ''
     const selectedTheme = localStorage.getItem('theme')
 
-    if (selectedTheme) {
+    if (selectedTheme && selectedTheme !== 'system') {
       document.documentElement.classList.add(selectedTheme)
     } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
       document.documentElement.classList.add('theme--dark')
@@ -45,7 +46,7 @@ function App() {
         }
       >
         <div className='fixed top-0 right-0 p-4 text-primary opacity-40'>
-          <ThemeSelect onChange={handleThemeChange} />
+          <ThemeSelect onChange={handleThemeChange} selectedTheme={theme} />
         </div>
 
         <div

--- a/src/components/ThemeSelect.tsx
+++ b/src/components/ThemeSelect.tsx
@@ -1,34 +1,35 @@
 import availableThemes from '../themes/availableThemes.ts'
 
 interface ThemeSelectProps {
+  selectedTheme: string | null
   onChange: (theme: string) => void
 }
 
-function ThemeSelect({ onChange }: ThemeSelectProps) {
-  const themes = availableThemes
+function ThemeSelect({ onChange, selectedTheme }: ThemeSelectProps) {
+  const themes = availableThemes,
+    themeNameMaxLength = 15
 
   return (
     <select
       name='themes'
       id='theme-select'
       onChange={e => onChange(e.target.value)}
-      defaultValue='default'
+      defaultValue={selectedTheme ?? 'default'}
       title='Select theme'
-      className='appearance-auto pr-2 cursor-pointer'
+      className='overflow-ellipsis cursor-pointer max-w-30 bg-background text-primary'
     >
       <option value='default' disabled hidden>
         Select theme
       </option>
-      <option value='system' className='text-slate-950'>
-        System
-      </option>
+      <option value='system'>System</option>
       {themes.map(theme => (
         <option
           key={`theme--${theme.toString().toLowerCase().split(' ').join('-')}`}
           value={`theme--${theme.toString().toLowerCase().split(' ').join('-')}`}
-          className='text-slate-950'
         >
-          {theme}
+          {theme.length > themeNameMaxLength
+            ? theme.substring(0, themeNameMaxLength) + '...'
+            : theme}
         </option>
       ))}
     </select>


### PR DESCRIPTION
## 📌 Description

This pull request includes several changes to improve the theme handling and selection in the application. The most important changes include updating the theme initialization and selection logic, enhancing the `ThemeSelect` component to show the current selected theme, and formatting the ESLint configuration.

## 🔍 Related Issues

No related issues.

## ✨ Changes Made

Improvements to theme handling:

* [`src/App.tsx`](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L11-R16): Updated the `theme` state initialization to use the value from `localStorage` if available, and modified the `handleThemeChange` function to store the selected theme in `localStorage` only if it is not empty.
* [`src/App.tsx`](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L27-R28): Modified the theme application logic to exclude the 'system' theme from being added to the `document.documentElement` class list.
* [`src/App.tsx`](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L48-R49): Passed the `selectedTheme` prop to the `ThemeSelect` component to ensure the correct theme is displayed.

Enhancements to `ThemeSelect` component:

* [`src/components/ThemeSelect.tsx`](diffhunk://#diff-2b3ef7154e71a8208d4f74258759c9b41a1c61703045e51c87bf131f0f0b1f3cR4-R32): Added a `selectedTheme` prop to the `ThemeSelect` component and updated the `defaultValue` to use this prop. Improved the styling and added a character limit for theme names.

ESLint configuration formatting:

* [`eslint.config.js`](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L11-R15): Reformatted the `extends` array for better readability.

## ✅ Checklist

- [x] My code follows the project's coding standards and guidelines
- [x] I have tested the changes locally to ensure they work as expected
- [x] No new warnings or errors in the console
- [x] The UI and functionality are responsive across different screen sizes.
- [x] I have updated the documentation (if necessary)

## 🚀 Additional Notes

N/A